### PR TITLE
AGR-2528 infinispan dockerhub => ECR (and versioned base image) code-changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM agrdocker/agr_base_linux_env
+ARG ALLIANCE_RELEASE=latest
+ARG REG=agrdocker
+FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
 
 ENTRYPOINT ["/opt/infinispan/bin/server.sh", "-b", "0.0.0.0"]


### PR DESCRIPTION
Code changes to support building the infinispan image using the versioned base image from and on ECR (through GoCD or `make`). Analoguous to alliance-genome/agr_ansible_devops#15.